### PR TITLE
Add pagination support for listing container instances

### DIFF
--- a/ecs.go
+++ b/ecs.go
@@ -132,7 +132,7 @@ func getContainerInstance(ecsCluster, ec2Instance string) (*ecs.ContainerInstanc
 		}
 
 		containerInstances = append(containerInstances, respInstances.ContainerInstances...)
-		return true
+		return !lastPage
 	})
 
 	if err != nil {

--- a/ecs.go
+++ b/ecs.go
@@ -118,20 +118,28 @@ func Drain(ecsCluster, ec2Instance string) error {
 }
 
 func getContainerInstance(ecsCluster, ec2Instance string) (*ecs.ContainerInstance, error) {
-	respList, err := ecsClient.ListContainerInstances(&ecs.ListContainerInstancesInput{Cluster: &ecsCluster})
-	if err != nil {
-		return nil, err
-	}
+	var containerInstances []*ecs.ContainerInstance
 
-	respInstances, err := ecsClient.DescribeContainerInstances(&ecs.DescribeContainerInstancesInput{
-		Cluster:            &ecsCluster,
-		ContainerInstances: respList.ContainerInstanceArns,
+	err := ecsClient.ListContainerInstancesPages(&ecs.ListContainerInstancesInput{Cluster: &ecsCluster}, func(page *ecs.ListContainerInstancesOutput, lastPage bool) bool {
+		respInstances, err := ecsClient.DescribeContainerInstances(&ecs.DescribeContainerInstancesInput{
+			Cluster:            &ecsCluster,
+			ContainerInstances: page.ContainerInstanceArns,
+		})
+
+		if err != nil {
+			fmt.Printf("Error describing container instances: %s", err)
+			return false
+		}
+
+		containerInstances = append(containerInstances, respInstances.ContainerInstances...)
+		return true
 	})
+
 	if err != nil {
 		return nil, err
 	}
 
-	for _, i := range respInstances.ContainerInstances {
+	for _, i := range containerInstances {
 		if *i.Ec2InstanceId == ec2Instance {
 			return i, nil
 		}


### PR DESCRIPTION
We've been seeing intermittent 504 errors on one of our services deployed via ECS. After looking into the Lambda logs, I noticed that there were a bunch of errors in the form of:

```
"i-09432453c14d92f6e" not found in the cluster "production": errorString null
```

This led me to the `getContainerInstance` function, which I noticed had no pagination. The max returned per page is 100, so any time a container instance was terminated and didn't happen to be in the first page, the container would not transition to draining and the tasks were killed abruptly.

The fix is to use the `ListContainerInstancesPages` function to ensure
we fetch all container instance: https://docs.aws.amazon.com/sdk-for-go/api/service/ecs/#ECS.ListContainerInstancesPages