### PR TITLE
build: disable CGO

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,8 @@ builds:
       - amd64
     goos:
       - linux
+    env:
+      - CGO_ENABLED=0
 archives:
   - format: zip
     # https://goreleaser.com/customization/archive/#packaging-only-the-binaries


### PR DESCRIPTION
Hello,

I'm testing the release binary with Lambda Function and got the following error:
```
/var/task/ecs-drain-lambda: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by /var/task/ecs-drain-lambda)
/var/task/ecs-drain-lambda: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by /var/task/ecs-drain-lambda)
2023/03/11 05:37:25 exit status 1
```

It seems like the build environment is too new compared to the lambda runtime environment (Amazon Linux 1). I think the binary doesn't require CGO so disabling it would be a simple solution.