### PR TITLE
README: mention the terraform module

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ When updating AMI for the ECS instances then ASG replaces them without ["Drainin
 **Note**: by default `us-east-1` region is selected, if you need to deploy it to the
 different region you can use `sls deploy -v --region ${AWS_REGION}`
 
+## Deploy with Terraform
+
+If you want to deploy *ecs-drain-lambda* function with Terraform, there is [ecs-drain-lambda](https://registry.terraform.io/modules/nabeken/ecs-drain-lambda/aws/latest) Terraform Module.
+
 ## Limitations
 
 - Function waits for 15 minutes for Drain to complete and fails with the timeout after


### PR DESCRIPTION
Hello,

Thanks to the recent update, I finally was able to deploy ecs-drain-lambda with Terraform.

I think it would be useful for others if the README has a link to my Terraform Module.