### PR TITLE
Update to provided.al2 runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
-build: export GOOS=linux
-build: 
-	go build -o bin/drain cmd/drain/main.go
-	@du -h bin/drain 
+GOOS=linux
+GOARCH=amd64
+CGO_ENABLED=0
+export
+
+build:
+	go build -tags lambda.norpc -o bootstrap cmd/drain/main.go
+	@du -h bootstrap
 
 deploy: build
 	sls deploy -v

--- a/serverless.yml
+++ b/serverless.yml
@@ -4,7 +4,7 @@ package:
 
 provider:
   name: aws
-  runtime: go1.x
+  runtime: provided.al2
   region: us-east-1
   memorySize: 128
   timeout: 900
@@ -26,12 +26,12 @@ provider:
 
 functions:
   main:
-    handler: bin/drain
+    handler: bootstrap
     package:
       exclude:
         - ./**
       include:
-        - ./bin/drain
+        - ./bootstrap
     events:
       - cloudwatchEvent:
           event:


### PR DESCRIPTION
Update the service runtime ahead of the deprecation of the go1.x runtime by AWS.

* disable CGO during build to avoid glibc version mismatch

* rename the executable `bootstrap` and place it in the task root directory as required by the new runtime

Closes #15