### PR TITLE
allow compiling for alternative architectures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GOOS=linux
-GOARCH=amd64
+GOARCH ?= amd64
 CGO_ENABLED=0
 export
 


### PR DESCRIPTION
The current `Makefile` sets the `GOARCH` to `amd64` preventing it from being set outside the `Makefile` to `arm64`.  If `GOARCH` is set outside of the make command, use that value, otherwise default to the existing `linux`.